### PR TITLE
Explanation spelling fix

### DIFF
--- a/lib/Perl/Critic/Policy/Plicease/ProhibitUnicodeDigitInRegexp.pm
+++ b/lib/Perl/Critic/Policy/Plicease/ProhibitUnicodeDigitInRegexp.pm
@@ -53,7 +53,7 @@ This policy doesn't take into account using the L<re> pragma.
 =cut
 
 use constant DESC => 'Using non-ASCII \d';
-use constant EXPL => 'The character class \d matches non-ASCI unicode digits.  ' .
+use constant EXPL => 'The character class \d matches non-ASCII unicode digits.  ' .
                      'Use [0-9] or the /a modifier (Perl 5.14+) instead.';
 
 sub supported_parameters { ()                                        }


### PR DESCRIPTION
Looks like the GitHub web editor adds a trailing linefeed to the file -- not that it wouldn't be a good thing IMO, but it's unrelated to the main topic of this change and I'm too lazy to weed that out with some other editor :)