### PR TITLE
detect signatures more accurately in newer PPI versions

### DIFF
--- a/lib/Perl/Critic/Policy/Plicease/ProhibitSignaturesAndAtUnderscore.pm
+++ b/lib/Perl/Critic/Policy/Plicease/ProhibitSignaturesAndAtUnderscore.pm
@@ -82,7 +82,8 @@ sub violates {
 
     my $subs = $elem->find('PPI::Statement::Sub') || [];
     foreach my $sub (@$subs) {
-      next unless defined $sub->prototype;
+      next unless( $PPI::Document::VERSION > 1.279 ?
+        @{$sub->find('PPI::Structure::Signature')} : defined $sub->prototype );
       my $symbols = $sub->find('PPI::Token::Symbol') || [];
       foreach my $symbol (@$symbols) {
         next unless $symbol->symbol eq '@_';


### PR DESCRIPTION
In versions > 1.279 PPI will more accurately determine the difference between prototypes and signatures, which breaks the test for the signature+@_ policy. This PR has a suggested fix for this. Once PPI is released, as per https://github.com/Perl-Critic/PPI/pull/280 , you could also just fully depend on it.